### PR TITLE
Historic block decoding fixes

### DIFF
--- a/src/chain_types.rs
+++ b/src/chain_types.rs
@@ -339,7 +339,7 @@ impl<'de> serde::Deserialize<'de> for DeserializableEnum {
                     map.next_entry::<String, DeserializableEnumFields>()?
                 {
                     variants.push(Variant { index, name, fields: value.0 });
-                    index += 1;
+                    index = index.saturating_add(1);
                 }
                 Ok(DeserializableEnum(variants))
             }
@@ -358,7 +358,7 @@ impl<'de> serde::Deserialize<'de> for DeserializableEnum {
                         DeserializableEnumSeq::Explicit(variant) => variant,
                     };
                     variants.push(variant);
-                    index += 1;
+                    index = index.saturating_add(1);
                 }
                 Ok(DeserializableEnum(variants))
             }

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -577,7 +577,7 @@ mod parser {
         if !input.token('<') {
             // No generics; just add the name to the registry
             registry.push(LookupNameInner::Named {
-                name: NameStr::from_str(name),
+                name: NameStr::from_str(&name),
                 params: Params::new(),
             });
             return Some(Ok(()));
@@ -592,7 +592,7 @@ mod parser {
             let loc = input.location().offset();
             Some(Err(ParseError::new_at(ParseErrorKind::ClosingAngleBracketMissing, loc)))
         } else {
-            registry.push(LookupNameInner::Named { name: NameStr::from_str(name), params });
+            registry.push(LookupNameInner::Named { name: NameStr::from_str(&name), params });
             Some(Ok(()))
         }
     }
@@ -689,10 +689,26 @@ mod parser {
     }
 
     // Parse the name/path of a type like `Foo`` or `a::b::Foo`.
-    fn parse_path<'a>(input: &mut StrTokens<'a>) -> &'a str {
-        str_slice_from(input, |toks| {
+    fn parse_path<'a>(input: &mut StrTokens<'a>) -> Cow<'a,str> {
+        let path_str = str_slice_from(input, |toks| {
             toks.sep_by(
                 |t| {
+                    // Handle paths like the '<Foo as Bar>' in <Foo as Bar>::Name.
+                    // We just count <'s and >'s and allow anything inside right now.
+                    if t.peek()? == '<' {
+                        let mut counter = 0;
+                        while let Some(tok) = t.next() {
+                            if tok == '<' {
+                                counter += 1;
+                            } else if tok == '>' {
+                                counter -= 1;
+                                if counter == 0 {
+                                    return Some(())
+                                }
+                            }
+                        }
+                    }
+
                     // First char should exist and be a letter.
                     if !t.peek()?.is_alphabetic() {
                         return None;
@@ -707,7 +723,41 @@ mod parser {
                 },
             )
             .consume();
-        })
+        });
+
+        normalize_whitespace(path_str)
+    }
+
+    // If we see more than one whitespace character next to each other, we remove any excess
+    // whitespace and normalize any whitespace to a single ' ' character. If we don't, we avoid
+    // allocating and return the str as is.
+    //
+    // Public only so that it can be tested with our other tests.
+    pub fn normalize_whitespace(str: &str) -> Cow<'_,str> {
+        let whitespaces_to_remove = str
+            .chars()
+            .zip(str.chars().skip(1))
+            .filter(|(a,b)| a.is_whitespace() && b.is_whitespace())
+            .count();
+
+        if whitespaces_to_remove > 0 {
+            let mut string = String::with_capacity(str.len() - whitespaces_to_remove);
+            let mut last_is_whitespace = false;
+            for c in str.chars(){
+                if c.is_whitespace() {
+                    if !last_is_whitespace {
+                        last_is_whitespace = true;
+                        string.push(' ');
+                    }
+                } else {
+                    last_is_whitespace = false;
+                    string.push(c);
+                }
+            }
+            Cow::Owned(string)
+        } else {
+            Cow::Borrowed(str)
+        }
     }
 
     // Skip over any whitespace, ignoring it.
@@ -759,6 +809,7 @@ mod test {
         expect_parse("(a,b,c,)");
 
         expect_parse("path::to::Foo"); // paths should work.
+        expect_parse("<Wibble as Bar<u32>>::to::Foo"); // paths should work.
         expect_parse("Foo");
         expect_parse("Foo<>");
         expect_parse("Foo<A>");
@@ -897,6 +948,42 @@ mod test {
         for ty_name_str in ty_name_strs {
             let ty_name = LookupName::parse(ty_name_str).unwrap();
             assert_eq!(ty_name.to_string(), ty_name_str);
+        }
+    }
+
+    #[test]
+    fn parsing_trait_as_type_paths_works() {
+        let cases = [
+            ("<Foo as Bar>::Item<A, B>", "<Foo as Bar>::Item<A, B>", vec!["A", "B"]),
+            ("<Foo \tas \n\nBar>::Item", "<Foo as Bar>::Item", vec![]),
+            ("<<Foo<Thing> \tas \n\nBar<A,B>> as Wibble>::Item", "<<Foo<Thing> as Bar<A,B>> as Wibble>::Item", vec![]),
+        ];
+
+        for (actual, expected, expected_params) in cases {
+            let name = LookupName::parse(actual)
+                .expect(&format!("should be able to parse '{actual}'"));
+
+            let actual_params: Vec<String> = name.def()
+                .unwrap_named()
+                .param_defs()
+                .map(|p| p.to_string())
+                .collect();
+
+            assert_eq!(actual_params, expected_params);
+            assert_eq!(name.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn normalize_whitespace_works() {
+        let cases: [(&str, Cow<'_,str>); 3] = [
+            ("hello there", Cow::Borrowed("hello there")),
+            ("hello  there", Cow::Owned("hello there".to_string())),
+            ("a \n\tb c\n\nd", Cow::Owned("a b c d".to_string())),
+        ];
+
+        for (input, output) in cases {
+            assert_eq!(parser::normalize_whitespace(input), output);
         }
     }
 }

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -970,8 +970,8 @@ mod test {
         ];
 
         for (actual, expected, expected_params) in cases {
-            let name =
-                LookupName::parse(actual).expect(&format!("should be able to parse '{actual}'"));
+            let name = LookupName::parse(actual)
+                .unwrap_or_else(|_| panic!("should be able to parse '{actual}'"));
 
             let actual_params: Vec<String> =
                 name.def().unwrap_named().param_defs().map(|p| p.to_string()).collect();

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -689,7 +689,7 @@ mod parser {
     }
 
     // Parse the name/path of a type like `Foo`` or `a::b::Foo`.
-    fn parse_path<'a>(input: &mut StrTokens<'a>) -> Cow<'a,str> {
+    fn parse_path<'a>(input: &mut StrTokens<'a>) -> Cow<'a, str> {
         let path_str = str_slice_from(input, |toks| {
             toks.sep_by(
                 |t| {
@@ -703,7 +703,7 @@ mod parser {
                             } else if tok == '>' {
                                 counter -= 1;
                                 if counter == 0 {
-                                    return Some(())
+                                    return Some(());
                                 }
                             }
                         }
@@ -733,17 +733,17 @@ mod parser {
     // allocating and return the str as is.
     //
     // Public only so that it can be tested with our other tests.
-    pub fn normalize_whitespace(str: &str) -> Cow<'_,str> {
+    pub fn normalize_whitespace(str: &str) -> Cow<'_, str> {
         let whitespaces_to_remove = str
             .chars()
             .zip(str.chars().skip(1))
-            .filter(|(a,b)| a.is_whitespace() && b.is_whitespace())
+            .filter(|(a, b)| a.is_whitespace() && b.is_whitespace())
             .count();
 
         if whitespaces_to_remove > 0 {
             let mut string = String::with_capacity(str.len() - whitespaces_to_remove);
             let mut last_is_whitespace = false;
-            for c in str.chars(){
+            for c in str.chars() {
                 if c.is_whitespace() {
                     if !last_is_whitespace {
                         last_is_whitespace = true;
@@ -956,18 +956,19 @@ mod test {
         let cases = [
             ("<Foo as Bar>::Item<A, B>", "<Foo as Bar>::Item<A, B>", vec!["A", "B"]),
             ("<Foo \tas \n\nBar>::Item", "<Foo as Bar>::Item", vec![]),
-            ("<<Foo<Thing> \tas \n\nBar<A,B>> as Wibble>::Item", "<<Foo<Thing> as Bar<A,B>> as Wibble>::Item", vec![]),
+            (
+                "<<Foo<Thing> \tas \n\nBar<A,B>> as Wibble>::Item",
+                "<<Foo<Thing> as Bar<A,B>> as Wibble>::Item",
+                vec![],
+            ),
         ];
 
         for (actual, expected, expected_params) in cases {
-            let name = LookupName::parse(actual)
-                .expect(&format!("should be able to parse '{actual}'"));
+            let name =
+                LookupName::parse(actual).expect(&format!("should be able to parse '{actual}'"));
 
-            let actual_params: Vec<String> = name.def()
-                .unwrap_named()
-                .param_defs()
-                .map(|p| p.to_string())
-                .collect();
+            let actual_params: Vec<String> =
+                name.def().unwrap_named().param_defs().map(|p| p.to_string()).collect();
 
             assert_eq!(actual_params, expected_params);
             assert_eq!(name.to_string(), expected);
@@ -976,7 +977,7 @@ mod test {
 
     #[test]
     fn normalize_whitespace_works() {
-        let cases: [(&str, Cow<'_,str>); 3] = [
+        let cases: [(&str, Cow<'_, str>); 3] = [
             ("hello there", Cow::Borrowed("hello there")),
             ("hello  there", Cow::Owned("hello there".to_string())),
             ("a \n\tb c\n\nd", Cow::Owned("a b c d".to_string())),

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -105,7 +105,10 @@ impl<'a> TypeRegistrySet<'a> {
     /// and a `visitor` which will be called in order to describe how to decode it.
     /// This just creates a [`LookupName`] under the hood and uses that to resolve the
     /// type.
-    pub fn resolve_type_str<'this, V: scale_type_resolver::ResolvedTypeVisitor<'this, TypeId = LookupName>>(
+    pub fn resolve_type_str<
+        'this,
+        V: scale_type_resolver::ResolvedTypeVisitor<'this, TypeId = LookupName>,
+    >(
         &'this self,
         type_name_str: &str,
         visitor: V,

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -113,9 +113,8 @@ impl<'a> TypeRegistrySet<'a> {
         type_name_str: &str,
         visitor: V,
     ) -> Result<V::Value, TypeRegistryResolveError> {
-        let type_id = LookupName::parse(type_name_str).map_err(|e| {
-            TypeRegistryResolveError::LookupNameInvalid(type_name_str.to_owned(), e)
-        })?;
+        let type_id = LookupName::parse(type_name_str)
+            .map_err(|e| TypeRegistryResolveError::LookupNameInvalid(type_name_str.into(), e))?;
         self.resolve_type(type_id, visitor)
     }
 }


### PR DESCRIPTION
- Support parsing trait as type paths like "<Foo as Trait<A>>::Item". Normalize any whitespace to be one space (I saw at least one type in metadata like `<Foo as\n       Something>::Item` but we'd like to be able to add it to our types list without the crazy spaces.
- Saturating add on a couple of variant things. We shouldn't see crazy indexes, but in the case of `Era` we need to support the full 256 variants!
- Allow prepending and appending to an existing `TypeRegistrySet`: this allows us to augment it. I use this to generate and prepend call types from the metadata to the registry so that we can decode nested calls like `utility.batch`