### PR TITLE
Make InsertName and LookupName Debug the same as Display

### DIFF
--- a/src/insert_name.rs
+++ b/src/insert_name.rs
@@ -52,7 +52,7 @@ impl std::error::Error for ParseError {}
 /// // will be resolved during lookup:
 /// InsertName::parse("Bar<A,B>").unwrap();
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 pub struct InsertName {
     pub(crate) name: String,
     pub(crate) params: SmallVec<[String; 4]>,
@@ -120,6 +120,12 @@ impl core::convert::TryFrom<String> for InsertName {
     type Error = ParseError;
     fn try_from(s: String) -> Result<Self, Self::Error> {
         Self::parse(&s)
+    }
+}
+
+impl core::fmt::Debug for InsertName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self)
     }
 }
 

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -42,7 +42,7 @@ pub use parser::{ParseError, ParseErrorKind};
 /// let array = LookupName::parse("[u8; 32]").unwrap();
 /// let tuple = LookupName::parse("(bool, u32, Vec<String>)").unwrap();
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct LookupName {
     registry: Registry,
     idx: usize,
@@ -68,6 +68,12 @@ impl PartialEq for LookupName {
     fn eq(&self, other: &Self) -> bool {
         // Bit of a hack, but it does the trick:
         self.to_string() == other.to_string()
+    }
+}
+
+impl core::fmt::Debug for LookupName {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.def())
     }
 }
 


### PR DESCRIPTION
This makes printing value types much nicer in https://github.com/paritytech/scale-value/pull/52. `TypeId`s almost must implement `Debug`, but there is currently no rule that they must impl `Display`, so the easiest thing to do was make the `Debug` impl for these types nicer (the full Debug one is not very helpful anyway).