### PR TITLE
Prep to release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+# 0.1.1
+
+- Support parsing trait as type paths like "<Foo as Trait>::Item", and allow prepending to `TypeRegistrySet`s ([#5](https://github.com/paritytech/scale-info-legacy/pull/5)).
+- Make InsertName and LookupName Debug the same as Display ([#6](https://github.com/paritytech/scale-info-legacy/pull/6)).
+
 # 0.1.0
 
 Initial release. See the README for more information.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
-# 0.1.1
+## 0.1.1 (2024-07-26)
 
 - Support parsing trait as type paths like "<Foo as Trait>::Item", and allow prepending to `TypeRegistrySet`s ([#5](https://github.com/paritytech/scale-info-legacy/pull/5)).
 - Make InsertName and LookupName Debug the same as Display ([#6](https://github.com/paritytech/scale-info-legacy/pull/6)).
 
-# 0.1.0
+## 0.1.0
 
 Initial release. See the README for more information.
 
-# 0.0.1
+## 0.0.1
 
 Placeholder release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
## 0.1.1 (2024-07-26)

- Support parsing trait as type paths like "<Foo as Trait>::Item", and allow prepending to `TypeRegistrySet`s ([#5](https://github.com/paritytech/scale-info-legacy/pull/5)).
- Make InsertName and LookupName Debug the same as Display ([#6](https://github.com/paritytech/scale-info-legacy/pull/6)).