### PR TITLE
Normalize LookupNames better after parsing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.2.1 (2024-09-25)
+
+- Normalize type names a little more, making a type like `<Foo \nas   Bar>::path ::to :: SomeType` in the metadata be normalized to `<Foo as Bar>::path::to::SomeType`, so it's easy to define such a type name for lookup.
+
 ## 0.2.0 (2024-08-08)
 
 - Allow types to be declared with the same name but different numbers of generic parameters (ie `BalanceOf<T>` and `BalanceOf<T,I>`). See [#9](https://github.com/paritytech/scale-info-legacy/pull/9). This is a breaking change because it removes an error variant related to generic parameter mismatch.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -776,7 +776,7 @@ mod parser {
     }
 
     fn strip_spaces_in_normalized_path(str: &str) -> Cow<'_, str> {
-        if str.find(":: ").is_some() || str.find(" ::").is_some() {
+        if str.contains(":: ") || str.contains(" ::") {
             let s = str.replace(":: ", "::").replace(" ::", "::");
             Cow::Owned(s)
         } else {

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -776,15 +776,15 @@ mod parser {
             String::with_capacity(str.len() - remove_in_path_part - remove_in_trait_as_part);
 
         // Replace whitespaces in "<Trait as Bar>" section for 1 space.
-        let mut last_is_whitespace = false;
+        let mut prev_is_whitespace = false;
         for c in trait_as_part.chars() {
             if c.is_whitespace() {
-                if !last_is_whitespace {
-                    last_is_whitespace = true;
+                if !prev_is_whitespace {
+                    prev_is_whitespace = true;
                     new_s.push(' ');
                 }
             } else {
-                last_is_whitespace = false;
+                prev_is_whitespace = false;
                 new_s.push(c);
             }
         }


### PR DESCRIPTION
On decoding storage entries, I ran into types that could have spacing in two areas, with an example showing both issues being `<Foo \nas   Bar>::path ::to :: SomeType`, ie too many spaces in the `<>` and extra spaces between the `::`s. The code here trims this space to normalize such type names (the above becomes `<Foo as Bar>::path::to::SomeType`), so that defining such type names and looking them up is always straightforward. 

Patch bump the version too for a quick release. 