### PR TITLE
Add support for describing Runtime APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.2.4 (2025-10-08)
+
+- Add support for defining Runtime APIs ([#22](https://github.com/paritytech/scale-info-legacy/pull/22)). This is useful because prior to V15 metadata, we had to Runtime API information, and so we can define such APIs here instead.
+
 ## 0.2.3 (2025-07-15)
 
 - Provide a [`ChainTypeRegistry::empty()`] function to allow an empty set of types to be used as a placeholder.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## 0.2.4 (2025-10-08)
 
-- Add support for defining Runtime APIs ([#22](https://github.com/paritytech/scale-info-legacy/pull/22)). This is useful because prior to V15 metadata, we had to Runtime API information, and so we can define such APIs here instead.
+- Add support for defining Runtime APIs ([#22](https://github.com/paritytech/scale-info-legacy/pull/22)). This is useful because prior to V15 metadata, we had no Runtime API information, and so we can define such APIs here instead.
 
 ## 0.2.3 (2025-07-15)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/chain_types.rs
+++ b/src/chain_types.rs
@@ -138,6 +138,7 @@ use serde::de::Error;
 ///                         "output": "RuntimeVersion"
 ///                     }
 ///                 }
+///             }
 ///         }
 ///     ]
 /// });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,6 @@ mod test_utils;
 // Export the main types here for ease of use:
 pub use {
     chain_types::ChainTypeRegistry, insert_name::InsertName, lookup_name::LookupName,
-    type_registry::TypeRegistry, type_registry_set::TypeRegistrySet, type_shape::TypeShape,
+    type_registry::RuntimeApiInput, type_registry::TypeRegistry,
+    type_registry_set::TypeRegistrySet, type_shape::TypeShape,
 };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,8 +18,9 @@
 //!
 //! The main types exposed here are as follows:
 //!
-//! - [`TypeRegistry`]: the lowest level type which one can populate with type information (via [`TypeRegistry::insert()`])
-//!   and then query to resolve some type name to the relevant information (via [`TypeRegistry::resolve_type()`]).
+//! - [`TypeRegistry`]: the lowest level type which one can populate with type information (via [`TypeRegistry::insert()`]
+//!   and [`TypeRegistry::insert_runtime_api()`]), and then query to resolve some type name to the relevant information
+//!   (via [`TypeRegistry::resolve_type()`] and [`TypeRegistry::runtime_api()`]).
 //! - [`TypeRegistrySet`]: a set of the above, which will resolve types (via [`TypeRegistrySet::resolve_type()`]) by working
 //!   through the inner type registries until it finds the relevant information (or doesn't find anything). This allows us
 //!   to combine type registries in different ways to alter how we resolve things.

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -521,12 +521,6 @@ mod parser {
         pub err: ParseErrorKind,
     }
 
-    impl From<core::convert::Infallible> for ParseError {
-        fn from(e: core::convert::Infallible) -> Self {
-            match e {}
-        }
-    }
-
     impl ParseError {
         /// Construct a new `ParseError` for tokens at the given location.
         pub fn new_at<E: Into<ParseErrorKind>>(err: E, loc: usize) -> Self {

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -521,6 +521,12 @@ mod parser {
         pub err: ParseErrorKind,
     }
 
+    impl From<core::convert::Infallible> for ParseError {
+        fn from(e: core::convert::Infallible) -> Self {
+            match e {}
+        }
+    }
+
     impl ParseError {
         /// Construct a new `ParseError` for tokens at the given location.
         pub fn new_at<E: Into<ParseErrorKind>>(err: E, loc: usize) -> Self {

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -449,8 +449,11 @@ impl TypeRegistry {
     }
 
     /// This method is like [`Self::insert_runtime_api()`], but is more forgiving
-    /// in terms of the inputs it accepts, allowing for easier usage at the cost of
+    /// in terms of the arguments it accepts, allowing for easier usage at the cost of
     /// potential errors if invalid values are provided.
+    ///
+    /// If there are no inputs to the Runtime API, [`Self::try_insert_runtime_api_without_inputs`]
+    /// can be used instead to avoid type inference issues.
     ///
     /// # Example
     ///

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -285,14 +285,14 @@ mod test {
     #[test]
     fn runtime_apis_works_avoiding_dupes() {
         let mut a = TypeRegistry::empty();
-        a.insert_runtime_api_str("A", "a1", vec![], "bool").unwrap();
-        a.insert_runtime_api_str("A", "a2", vec![], "bool").unwrap();
+        a.try_insert_runtime_api_without_inputs("A", "a1", "bool").unwrap();
+        a.try_insert_runtime_api_without_inputs("A", "a2", "bool").unwrap();
 
         let mut b = TypeRegistry::empty();
-        b.insert_runtime_api_str("A", "a2", vec![], "bool").unwrap();
+        b.try_insert_runtime_api_without_inputs("A", "a2", "bool").unwrap();
 
         let mut c = TypeRegistry::empty();
-        c.insert_runtime_api_str("B", "b1", vec![], "bool").unwrap();
+        c.try_insert_runtime_api_without_inputs("B", "b1", "bool").unwrap();
 
         // Resolving will look in c, then b, then a.
         let types = TypeRegistrySet::from_iter([a, b, c]);


### PR DESCRIPTION
Adds support for describing Runtime APIs in our type information, and then accessing that via `TypeRegistry` and `TypeRegistrySet`'s.

That has been made use of in [frame-decode](https://github.com/paritytech/frame-decode/pull/46) so I'm happy with the APIs now.