### PR TITLE
Support Ord/Eq in LookupName and InsertName and prep to release 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## 0.2.5 (2025-11-03)
 
-- Add proper support for `PartialEq`, `Eq`, `PartialOrd` and `Ord` to `LookupName` (and `Ord` + `PartialOrd` to `InsertName`).
+- Add proper support for `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` to `LookupName` (and `Ord` + `PartialOrd` to `InsertName`). This most notably allows both of these types to be used as keys in HashMaps / BTreeMaps.
 
 ## 0.2.4 (2025-10-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.2.5 (2025-11-03)
+
+- Add proper support for `PartialEq`, `Eq`, `PartialOrd` and `Ord` to `LookupName` (and `Ord` + `PartialOrd` to `InsertName`).
+
 ## 0.2.4 (2025-10-08)
 
 - Add support for defining Runtime APIs ([#22](https://github.com/paritytech/scale-info-legacy/pull/22)). This is useful because prior to V15 metadata, we had no Runtime API information, and so we can define such APIs here instead.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.2.4"
+version = "0.2.5"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/insert_name.rs
+++ b/src/insert_name.rs
@@ -47,7 +47,7 @@ pub enum ParseError {
 /// // will be resolved during lookup:
 /// InsertName::parse("Bar<A,B>").unwrap();
 /// ```
-#[derive(Clone, PartialEq, Eq, Hash)]
+#[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct InsertName {
     pub(crate) name: String,
     pub(crate) params: SmallVec<[String; 4]>,

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -1017,7 +1017,7 @@ mod test {
             // if the types are supposed to be equal, hashes should be equal too.
             if expected {
                 // Easiest way to check hashes is to see if two items hash to the same
-                // location in a set. If hashes are different then locations _probably_ be too.
+                // location in a set. If hashes are different then locations _probably_ will be too.
                 // Pre-init the HashSet with a capacity that should limit collision likelihood.
                 // We could find a deterministic hasher and just check the raw hash values which
                 // would be better but more complicated.
@@ -1055,6 +1055,12 @@ mod test {
         };
 
         assert_eq!(a, b);
+
+        // Check that these items hash the same even though they are different internally.
+        let mut set = hashbrown::HashSet::with_capacity(1024);
+        set.insert(&a);
+        set.insert(&b);
+        assert_eq!(set.len(), 1, "hash mismatch between {a} and {b}");
     }
 
     #[test]

--- a/src/lookup_name.rs
+++ b/src/lookup_name.rs
@@ -16,6 +16,8 @@
 //! This module provides a struct, [`LookupName`]. This struct represents a single concrete type
 //! that can be looked up in the [`crate::TypeRegistry`].
 
+use core::cmp::Ordering;
+
 use alloc::{
     borrow::{Cow, ToOwned},
     format,
@@ -63,13 +65,43 @@ impl Default for LookupName {
     }
 }
 
-#[cfg(test)]
-impl PartialEq for LookupName {
-    fn eq(&self, other: &Self) -> bool {
-        // Bit of a hack, but it does the trick:
-        self.to_string() == other.to_string()
+impl PartialOrd for LookupName {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
     }
 }
+
+impl Ord for LookupName {
+    fn cmp(&self, other: &Self) -> Ordering {
+        if let o @ (Ordering::Greater | Ordering::Less) = self.pallet.cmp(&other.pallet) {
+            return o;
+        }
+
+        let a_idx = self.idx;
+        let a_registry = &self.registry;
+        let b_idx = other.idx;
+        let b_registry = &other.registry;
+
+        LookupNameInner::cmp(a_idx, a_registry, b_idx, b_registry)
+    }
+}
+
+impl PartialEq for LookupName {
+    fn eq(&self, other: &Self) -> bool {
+        if self.pallet != other.pallet {
+            return false;
+        }
+
+        let a_idx = self.idx;
+        let a_registry = &self.registry;
+        let b_idx = other.idx;
+        let b_registry = &other.registry;
+
+        LookupNameInner::eq(a_idx, a_registry, b_idx, b_registry)
+    }
+}
+
+impl Eq for LookupName {}
 
 impl core::fmt::Debug for LookupName {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
@@ -482,7 +514,7 @@ type Params = SmallVec<[usize; 2]>;
 type NameStr = SmallString<[u8; 16]>;
 
 /// The internal representation of some type name.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum LookupNameInner {
     /// Types like `Vec<T>`, `Foo` and `path::to::Bar<A,B>`, `i32`, `bool`
     /// etc are _named_ types.
@@ -504,6 +536,73 @@ pub enum LookupNameInner {
         /// The fixed length of the array.
         length: usize,
     },
+}
+
+// If the orderings match, do nothing, else return the ordering.
+macro_rules! ord_eq {
+    ($a:expr) => {
+        if let o @ (Ordering::Greater | Ordering::Less) = $a {
+            return o;
+        }
+    };
+    ($a:expr, $b:expr) => {
+        if let o @ (Ordering::Greater | Ordering::Less) = $a.cmp(&$b) {
+            return o;
+        }
+    };
+}
+
+impl LookupNameInner {
+    fn cmp(
+        a_idx: usize,
+        a_registry: &Registry,
+        b_idx: usize,
+        b_registry: &Registry,
+    ) -> core::cmp::Ordering {
+        let a = &a_registry[a_idx];
+        let b = &b_registry[b_idx];
+
+        match (a, b) {
+            // Same variants; compare ordering of each field:
+            (
+                LookupNameInner::Named { name: a_name, params: a_params },
+                LookupNameInner::Named { name: b_name, params: b_params },
+            ) => {
+                ord_eq!(a_name, b_name);
+                ord_eq!(a_params.len(), b_params.len());
+
+                for (a_param, b_param) in a_params.iter().zip(b_params.iter()) {
+                    ord_eq!(LookupNameInner::cmp(*a_param, a_registry, *b_param, b_registry));
+                }
+            }
+            (
+                LookupNameInner::Unnamed { params: a_params },
+                LookupNameInner::Unnamed { params: b_params },
+            ) => {
+                ord_eq!(a_params.len(), b_params.len());
+
+                for (a_param, b_param) in a_params.iter().zip(b_params.iter()) {
+                    ord_eq!(LookupNameInner::cmp(*a_param, a_registry, *b_param, b_registry));
+                }
+            }
+            (
+                LookupNameInner::Array { param: a_param, length: a_len },
+                LookupNameInner::Array { param: b_param, length: b_len },
+            ) => {
+                ord_eq!(a_len, b_len);
+                ord_eq!(LookupNameInner::cmp(*a_param, a_registry, *b_param, b_registry));
+            }
+            // Different variants; arbitrary ordering between them:
+            (LookupNameInner::Named { .. }, _) => return Ordering::Greater,
+            (LookupNameInner::Unnamed { .. }, _) => return Ordering::Greater,
+            (LookupNameInner::Array { .. }, _) => return Ordering::Greater,
+        }
+        Ordering::Equal
+    }
+
+    fn eq(a_idx: usize, a_registry: &Registry, b_idx: usize, b_registry: &Registry) -> bool {
+        LookupNameInner::cmp(a_idx, a_registry, b_idx, b_registry).is_eq()
+    }
 }
 
 // Logic for parsing strings into type names.
@@ -848,6 +947,69 @@ mod test {
             Ok(tn) => panic!("parsing '{input}' is expected to have failed, but got {tn:?}"),
             Err(_e) => {}
         }
+    }
+
+    #[test]
+    fn basic_eq_works() {
+        let cmps = [
+            // basic named types
+            (expect_parse("path::to::Foo"), expect_parse("path::to::Foo"), true),
+            (expect_parse("Foo<u8>"), expect_parse("Foo<u8>"), true),
+            (expect_parse("Foo<u8>"), expect_parse("Foo<bool>"), false),
+            (expect_parse("path::to::Foo").in_pallet("bar"), expect_parse("path::to::Foo"), false),
+            (
+                expect_parse("path::to::Foo").in_pallet("bar"),
+                expect_parse("path::to::Foo").in_pallet("bar"),
+                true,
+            ),
+            (
+                expect_parse("path::for::Foo").in_pallet("bar"),
+                expect_parse("path::to::Foo").in_pallet("bar"),
+                false,
+            ),
+            (expect_parse("path::for::Foo"), expect_parse("path::to::Foo"), false),
+            // arrays
+            (expect_parse("[u8; 32]"), expect_parse("[u8; 32]"), true),
+            (expect_parse("[u8; 32]"), expect_parse("[u8; 28]"), false),
+            (expect_parse("[u8; 32]"), expect_parse("[u16; 32]"), false),
+            // unnameds
+            (expect_parse("()"), expect_parse("()"), true),
+            (expect_parse("(bool,)"), expect_parse("(bool,)"), true),
+            (expect_parse("(char, u8, String)"), expect_parse("(char, u8, String)"), true),
+            (expect_parse("(u8, char, String)"), expect_parse("(char, u8, String)"), false),
+        ];
+
+        for (a, b, expected) in cmps {
+            assert_eq!(a == b, expected, "{a} should equal {b}: {expected}");
+        }
+    }
+
+    #[test]
+    fn eq_works_with_different_registries() {
+        // These two types have differently ordered registries but
+        // are actually the same type and so should be equal.
+        let a = LookupName {
+            registry: SmallVec::from_iter([
+                LookupNameInner::Named { name: "Foo".into(), params: SmallVec::from_iter([1]) },
+                LookupNameInner::Array { param: 2, length: 32 },
+                LookupNameInner::Unnamed { params: SmallVec::from_iter([]) },
+            ]),
+            idx: 0,
+            pallet: None,
+        };
+        let b = LookupName {
+            registry: SmallVec::from_iter([
+                LookupNameInner::Array { param: 1, length: 32 },
+                LookupNameInner::Unnamed { params: SmallVec::from_iter([]) },
+                LookupNameInner::Named { name: "Foo".into(), params: SmallVec::from_iter([0]) },
+                // this type isn't referenced so should be ignored:
+                LookupNameInner::Array { param: 0, length: 128 },
+            ]),
+            idx: 2,
+            pallet: None,
+        };
+
+        assert_eq!(a, b);
     }
 
     #[test]


### PR DESCRIPTION
This allows `LookupName` (and `InsertName`) to be used as keys in HashMaps/BTreeMaps as needed.

The ordering/equality takes into account the fact that two names which are semantically equivalent but structurally different (ie the underlying types in their registries are a different order) are still considered equal.