### PR TITLE
Add Unknown type and prep for 0.2.6 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog].
 
 ## 0.2.6 (2025-11-05)
 
-- Add an `Unknown` type to the default types that are defined by a `TypeRegistry`. Arbitrary bytes are highly likely to fail to decode into `Unknown`, and so it can be used to denote types that we know exist (and perhaps need to have defined) but don't know how to actually decode.
+- Add a `special::Unknown` type to the default types that are defined by a `TypeRegistry`. Arbitrary bytes are highly likely to fail to decode into `special::Unknown`, and so it can be used to denote types that we know exist (and perhaps need to have defined) but don't know how to actually decode.
 
 ## 0.2.5 (2025-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.2.6 (2025-11-05)
+
+- Add an `Unknown` type to the default types that are defined by a `TypeRegistry`. Arbitrary bytes are highly likely to fail to decode into `Unknown`, and so it can be used to denote types that we know exist (and perhaps need to have defined) but don't know how to actually decode.
+
 ## 0.2.5 (2025-11-03)
 
 - Add proper support for `PartialEq`, `Eq`, `PartialOrd`, `Ord` and `Hash` to `LookupName` (and `Ord` + `PartialOrd` to `InsertName`). This most notably allows both of these types to be used as keys in HashMaps / BTreeMaps.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.2.5"
+version = "0.2.6"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -180,11 +180,11 @@ impl TypeRegistry {
         {
             let name = |i| {
                 if i == 0 {
-                    format!("special::Unknown")
+                    "special::Unknown".to_owned()
                 } else if i < 16 {
                     format!("special::Unknown{i}")
                 } else {
-                    format!("()")
+                    "()".to_owned()
                 }
             };
 

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -20,6 +20,7 @@ use crate::insert_name::{self, InsertName};
 use crate::lookup_name::{self, LookupName, LookupNameDef};
 use crate::type_shape::{self, Primitive, TypeShape, VariantDesc};
 use alloc::borrow::ToOwned;
+use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -171,6 +172,40 @@ impl TypeRegistry {
     pub fn basic() -> Self {
         let mut registry = TypeRegistry::empty();
 
+        // Insert an "Unknown" type. The point of this type is that is resolves
+        // successfully but to something which should be extremely unlikely to successfully
+        // match any sequence of bytes (it would match only 0xDEADDEADDEADDEADDEADDEADDEADDEAD).
+        // Thus, it can be used to express that we know _of_ some type but if we actually need
+        // to use the type at runtime, it'll fail.
+        {
+            let name = |i| {
+                if i == 0 {
+                    format!("special::Unknown")
+                } else if i < 16 {
+                    format!("special::Unknown{i}")
+                } else {
+                    format!("()")
+                }
+            };
+
+            for i in 0..16 {
+                let this_name = name(i);
+                let next_name = name(i + 1);
+                let shape = TypeShape::EnumOf(vec![type_shape::Variant {
+                    // 0xDE, 0xAD, 0xDE, 0xAD ...
+                    index: if i % 2 == 0 { 0xDE } else { 0xAD },
+                    name: "Unknown".to_owned(),
+                    fields: type_shape::VariantDesc::TupleOf(vec![
+                        LookupName::parse(&next_name).unwrap()
+                    ]),
+                }]);
+
+                let name = InsertName::from_str(&this_name).unwrap();
+                registry.insert(name, shape);
+            }
+        }
+
+        // Basic types that we expect to work by default.
         let basic_types = [
             ("bool", TypeShape::Primitive(Primitive::Bool)),
             ("char", TypeShape::Primitive(Primitive::Char)),


### PR DESCRIPTION
`TypeRegistry::new()` will now define a `special::Unknown` type. This type matches only the bytes `0xDEADDEADDEADDEADDEADDEADDEADDEAD`, and is supposed to be used in cases where we need to have a valid type defined, but don't know how to actually decode this type (the point being that trying to decode into it should likely fail).

Also prep a 0.2.6 release to contain this addition.