### PR TITLE
Prep for 0.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ The format is based on [Keep a Changelog].
 
 ## 0.3.0 (2025-11-10)
 
-- Improve the `special::Unknown` type to be quicker to construct and to deny _any_ decoding.
 - Add a couple of helpers to `LookupName` (`::array()` and `::unnamed()`) to make it easy to construct tuple or array `LookupName`s without any shenanigane involving wrapping strings in tuple/array syntax and re-parsing. 
 - Improve Runtime API iteration and add better guarantees around it so that upstream libraries can use it more reliably.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.3.0 (2025-11-10)
+
+- Improve the `special::Unknown` type to be quicker to construct and to deny _any_ decoding.
+- Add a couple of helpers to `LookupName` (`::array()` and `::unnamed()`) to make it easy to construct tuple or array `LookupName`s without any shenanigane involving wrapping strings in tuple/array syntax and re-parsing. 
+- Improve Runtime API iteration and add better guarantees around it so that upstream libraries can use it more reliably.
+
 ## 0.2.6 (2025-11-05)
 
 - Add a `special::Unknown` type to the default types that are defined by a `TypeRegistry`. Arbitrary bytes are highly likely to fail to decode into `special::Unknown`, and so it can be used to denote types that we know exist (and perhaps need to have defined) but don't know how to actually decode.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.2.6"
+version = "0.3.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -579,6 +579,16 @@ impl TypeRegistry {
         })
     }
 
+    /// Return an iterator over each of the Runtime API method names in a given trait.
+    pub fn runtime_apis_in_trait(&self, trait_name: &str) -> impl Iterator<Item = &'_ str> {
+        let Some(apis) = self.runtime_apis.get(trait_name) else {
+            return Either::A(core::iter::empty());
+        };
+
+        let it = apis.keys().map(|k| &**k);
+        Either::B(it)
+    }
+
     /// Extend this type registry with the one provided. In case of any matches, the provided types
     /// and runtime API methods will overwrite the existing ones.
     pub fn extend(&mut self, other: TypeRegistry) {

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -120,6 +120,19 @@ pub struct TypeRegistry {
     runtime_apis: HashMap<String, HashMap<String, RuntimeApi>>,
 }
 
+/// This is handed back when we iterate over Runtime APIs via [`TypeRegistry::runtime_apis()`].
+/// First, [`RuntimeApiName::Trait`] will be returned to indicate which trait is being iterated
+/// over, and then [`RuntimeApiName::Method`] will be returned with the name of each method in the
+/// aforementioned trait.
+///
+/// Each trait will be iterated exactly once.
+pub enum RuntimeApiName<'a> {
+    /// The name of the trait that the methods given next are defined on.
+    Trait(&'a str),
+    /// The name of a method in the most recently returned [`RuntimeApiName::Trait`].
+    Method(&'a str),
+}
+
 /// This represents a single Runtime API.
 #[derive(Debug, Clone)]
 pub struct RuntimeApi {
@@ -555,12 +568,15 @@ impl TypeRegistry {
         self.runtime_apis.get(trait_name)?.get(method_name)
     }
 
-    /// Return an iterator of tuples of `(trait_name, method_name)` for all runtime APIs
-    /// that exist in this registry.
-    pub fn runtime_apis(&self) -> impl Iterator<Item = (&str, &str)> {
-        self.runtime_apis
-            .iter()
-            .flat_map(|(k, v)| v.keys().map(move |method_name| (k.as_str(), &**method_name)))
+    /// Return an iterator over each of the Runtime APIs that has been defined. First,
+    /// [`RuntimeApiName::Trait`] is returned to indicate the trait being iterated over next,
+    /// and then [`RuntimeApiName::Method`] is returned for each of the method names in that
+    /// trait. A trait will only be iterated over once.
+    pub fn runtime_apis(&self) -> impl Iterator<Item = RuntimeApiName<'_>> {
+        self.runtime_apis.iter().flat_map(|(k, v)| {
+            core::iter::once(RuntimeApiName::Trait(k))
+                .chain(v.keys().map(|method| RuntimeApiName::Method(method)))
+        })
     }
 
     /// Extend this type registry with the one provided. In case of any matches, the provided types

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -156,9 +156,8 @@ impl<'a> TypeRegistrySet<'a> {
 
         // Now we can iterate over this aggregation to match the format of `TypeRegistry::runtime_apis`.
         all_apis.into_iter().flat_map(|(trait_name, method_names)| {
-            core::iter::once(RuntimeApiName::Trait(trait_name)).chain(
-                method_names.into_iter().map(|method_name| RuntimeApiName::Method(method_name)),
-            )
+            core::iter::once(RuntimeApiName::Trait(trait_name))
+                .chain(method_names.into_iter().map(RuntimeApiName::Method))
         })
     }
 
@@ -173,15 +172,7 @@ impl<'a> TypeRegistrySet<'a> {
             .iter()
             .rev()
             .flat_map(|registry| registry.runtime_apis_in_trait(trait_name))
-            .filter_map(
-                move |method_name| {
-                    if seen.insert(method_name) {
-                        None
-                    } else {
-                        Some(method_name)
-                    }
-                },
-            )
+            .filter(move |method_name| !seen.insert(method_name))
     }
 }
 
@@ -342,7 +333,7 @@ mod test {
                 }
                 RuntimeApiName::Method(name) => {
                     // A trait name should have been given already.
-                    assert!(current_trait != "");
+                    assert!(!current_trait.is_empty());
                     // The method name should not have been given before.
                     assert!(!all_apis.entry(current_trait).or_default().contains(name));
 

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -139,7 +139,7 @@ impl<'a> TypeRegistrySet<'a> {
     /// and then [`RuntimeApiName::Method`] is returned for each of the method names in that
     /// trait. A trait will only be iterated over once.
     pub fn runtime_apis(&self) -> impl Iterator<Item = RuntimeApiName<'_>> {
-        let it = self.registries.iter().rev().flat_map(move |registry| registry.runtime_apis());
+        let it = self.registries.iter().rev().flat_map(|registry| registry.runtime_apis());
 
         // We need to aggregate across our registries so that we return each
         // trait name / entry exactly once.
@@ -160,6 +160,28 @@ impl<'a> TypeRegistrySet<'a> {
                 method_names.into_iter().map(|method_name| RuntimeApiName::Method(method_name)),
             )
         })
+    }
+
+    /// Return an iterator over each of the Runtime API method names in a given trait.
+    pub fn runtime_apis_in_trait<'this, 'tn>(
+        &'this self,
+        trait_name: &'tn str,
+    ) -> impl Iterator<Item = &'this str> + use<'this, 'tn> {
+        let mut seen = HashSet::<&str>::new();
+
+        self.registries
+            .iter()
+            .rev()
+            .flat_map(|registry| registry.runtime_apis_in_trait(trait_name))
+            .filter_map(
+                move |method_name| {
+                    if seen.insert(method_name) {
+                        None
+                    } else {
+                        Some(method_name)
+                    }
+                },
+            )
     }
 }
 


### PR DESCRIPTION
- Add a couple of helpers to `LookupName` (`::array()` and `::unnamed()`) to make it easy to construct tuple or array `LookupName`s without any shenanigane involving wrapping strings in tuple/array syntax and re-parsing. 
- Improve Runtime API iteration and add better guarantees around it so that upstream libraries can use it more reliably.