### PR TITLE
Prep to release 0.3.2: tweaks to improve testability of type registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.3.2 (2025-11-18)
+
+A few tweaks to make it easier to test type registries:
+
+- Support converting between `InsertName` and `LookupName`.
+- Add `.keys()` iterator to iterate over concrete keys in a `TypeRegistry` or `TypeRegistrySet`; this helps with tests which require iterating over types.
+- Add `.spec_version_ranges()` to `ChainTypeRegistry` to allow discovering which spec versions have types defined (so that we can be sure to try them all via the above).
+
 ## 0.3.1 (2025-11-13)
 
 - Support parsing slice type names like `&[u8]` and `&[bool]`. Slice based names were not expected to exist, but show up in a couple of constant type names in older metadatas. `&[T]` is parsed and handled as if it were `Vec<T>`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/chain_types.rs
+++ b/src/chain_types.rs
@@ -183,6 +183,11 @@ impl ChainTypeRegistry {
         TypeRegistrySet::from_iter(all)
     }
 
+    /// Return the specific spec version ranges that we've defined types for.
+    pub fn spec_version_ranges(&self) -> impl Iterator<Item = (u64, u64)> + use<'_> {
+        self.for_spec.iter().map(|(range, _)| *range)
+    }
+
     /// Extend this chain type registry with the one provided. In case of any matches, the provided types
     /// will overwrite the existing ones.
     pub fn extend(&mut self, other: ChainTypeRegistry) {

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -20,7 +20,6 @@ use crate::insert_name::{self, InsertName};
 use crate::lookup_name::{self, LookupName, LookupNameDef};
 use crate::type_shape::{self, Primitive, TypeShape, VariantDesc};
 use alloc::borrow::ToOwned;
-use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -292,7 +292,7 @@ impl TypeRegistry {
         self.types.keys().map(|key| {
             let insert_name = InsertName {
                 name: key.name.clone(),
-                params: (0..key.generic_params).map(|_| format!("()")).collect(),
+                params: (0..key.generic_params).map(|_| "()".to_owned()).collect(),
                 pallet: key.pallet.clone(),
             };
             LookupName::from(insert_name)

--- a/src/type_registry.rs
+++ b/src/type_registry.rs
@@ -20,6 +20,7 @@ use crate::insert_name::{self, InsertName};
 use crate::lookup_name::{self, LookupName, LookupNameDef};
 use crate::type_shape::{self, Primitive, TypeShape, VariantDesc};
 use alloc::borrow::ToOwned;
+use alloc::format;
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
@@ -283,6 +284,19 @@ impl TypeRegistry {
         }
 
         registry
+    }
+
+    /// Return a [`LookupName`] corresponding to one concrete type for every entry in the registry.
+    /// Any generic parameters are substituted for `()` in order that we can return valid concrete types.
+    pub fn keys(&self) -> impl Iterator<Item = LookupName> + use<'_> {
+        self.types.keys().map(|key| {
+            let insert_name = InsertName {
+                name: key.name.clone(),
+                params: (0..key.generic_params).map(|_| format!("()")).collect(),
+                pallet: key.pallet.clone(),
+            };
+            LookupName::from(insert_name)
+        })
     }
 
     /// Insert a new type into the registry.


### PR DESCRIPTION
A few tweaks to make it easier to test type registries:

- Support converting between `InsertName` and `LookupName`.
- Add `.keys()` iterator to iterate over concrete keys in a `TypeRegistry` or `TypeRegistrySet`; this helps with tests which require iterating over types.
- Add `.spec_version_ranges()` to `ChainTypeRegistry` to allow discovering which spec versions have types defined (so that we can be sure to try them all via the above).