### PR TITLE
Prep 0.4.0 release: Differentiate between tuple and unnamed structs in type definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.4.0 (2025-11-20)
+
+Differentiate between `Foo: [ "bool", "Vec<String>" ]` and `Foo: "(bool, Vec<String>)"` when defining types. Previously, both were treated as tuple types, but now the former is treated like an unnamed composite/struct type (which has a name/path) and the latter a tuple type (which does not), which becomes useful when we want to translate or codegen from this sort of information.
+
 ## 0.3.2 (2025-11-18)
 
 A few tweaks to make it easier to test type registries:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.3.2"
+version = "0.4.0"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 

--- a/src/type_registry_set.rs
+++ b/src/type_registry_set.rs
@@ -282,7 +282,7 @@ mod test {
         .unwrap();
 
         let mut b = TypeRegistry::empty();
-        b.insert_str("bitvec::order::Lsb0", TypeShape::StructOf(vec![])).unwrap();
+        b.insert_str("bitvec::order::Lsb0", TypeShape::NamedStructOf(vec![])).unwrap();
 
         let mut c = TypeRegistry::empty();
         c.insert_str("Store", TypeShape::Primitive(Primitive::U8)).unwrap();
@@ -381,8 +381,8 @@ mod test {
         let mut b = TypeRegistry::empty();
         b.insert(InsertName::parse("u32").unwrap(), TypeShape::Primitive(Primitive::U32));
         b.insert(InsertName::parse("u64").unwrap(), TypeShape::Primitive(Primitive::U64));
-        b.insert(InsertName::parse("Foo").unwrap(), TypeShape::StructOf(vec![]));
-        b.insert(InsertName::parse("Bar").unwrap(), TypeShape::StructOf(vec![]));
+        b.insert(InsertName::parse("Foo").unwrap(), TypeShape::NamedStructOf(vec![]));
+        b.insert(InsertName::parse("Bar").unwrap(), TypeShape::NamedStructOf(vec![]));
 
         let mut c = TypeRegistry::empty();
         c.insert(InsertName::parse("Foo").unwrap(), TypeShape::Primitive(Primitive::U32));

--- a/src/type_shape.rs
+++ b/src/type_shape.rs
@@ -28,9 +28,9 @@ pub use scale_type_resolver::{BitsOrderFormat, BitsStoreFormat, Primitive};
 pub enum TypeShape {
     /// A "named composite" type in scale-info. This contains a list
     /// of fields.
-    StructOf(Vec<Field>),
+    NamedStructOf(Vec<Field>),
     /// An "unnamed composite" type in scale-info.
-    TupleOf(Vec<LookupName>),
+    UnnamedStructOf(Vec<LookupName>),
     /// An enum containing a list of variants.
     EnumOf(Vec<Variant>),
     /// A sequence of some type.
@@ -79,7 +79,7 @@ pub struct Variant {
 #[cfg_attr(test, derive(PartialEq))]
 pub enum VariantDesc {
     /// named variant fields are basically a struct.
-    StructOf(Vec<Field>),
+    NamedStructOf(Vec<Field>),
     /// Unnamed variant fields are basically a tuple of type descriptions.
-    TupleOf(Vec<LookupName>),
+    UnnamedStructOf(Vec<LookupName>),
 }


### PR DESCRIPTION
Differentiate between `Foo: [ "bool", "Vec<String>" ]` and `Foo: "(bool, Vec<String>)"` when defining types. Previously, both were treated as tuple types, but now the former is treated like an unnamed composite/struct type (which has a name/path) and the latter a tuple type (which does not), which becomes useful when we want to translate or codegen from this sort of information.