### PR TITLE
Prep 0.4.1 release: support underscores in paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.4.1 (2025-12-02)
+
+Paths containing underscore like `relay_chain::Foo`, and starting with underscores like `_foo::Bar` are now supported.
+
 ## 0.4.0 (2025-11-20)
 
 Differentiate between `Foo: [ "bool", "Vec<String>" ]` and `Foo: "(bool, Vec<String>)"` when defining types. Previously, both were treated as tuple types, but now the former is treated like an unnamed composite/struct type (which has a name/path) and the latter a tuple type (which does not), which becomes useful when we want to translate or codegen from this sort of information.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
Paths containing underscore like `relay_chain::Foo`, and starting with underscores like `_foo::Bar` are now supported.