### PR TITLE
Prep to release 0.4.2: support for reference type names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ The format is based on [Keep a Changelog].
 
 [Keep a Changelog]: http://keepachangelog.com/en/1.0.0/
 
+## 0.4.2 (2026-01-13)
+
+- Support type names like `&'static [u8]`, `&'static str` and `&str`, expanding on the support added in 0.3.1 for type names that are unexpected but do show up in some historic metadatas.
+
 ## 0.4.1 (2025-12-02)
 
 Paths containing underscore like `relay_chain::Foo`, and starting with underscores like `_foo::Bar` are now supported.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scale-info-legacy"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Parity Technologies <admin@parity.io>"]
 edition = "2021"
 


### PR DESCRIPTION
- Support type names like `&'static [u8]`, `&'static str` and `&str`, expanding on the support added in 0.3.1 for type names that are unexpected but do show up in some historic metadatas.